### PR TITLE
The admin system has now had it's 'ClaimExport' renamed to 'Export'

### DIFF
--- a/app/admin/admin_exports.rb
+++ b/app/admin/admin_exports.rb
@@ -1,4 +1,4 @@
-ActiveAdmin.register Admin::ClaimExport, as: 'ClaimExports' do
+ActiveAdmin.register Admin::Export, as: 'Exports' do
 # See permitted parameters documentation:
 # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
 #
@@ -11,17 +11,14 @@ ActiveAdmin.register Admin::ClaimExport, as: 'ClaimExports' do
 #   permitted << :other if params[:action] == 'create' && current_user.admin?
 #   permitted
 # end
-  show do |claim_export|
+  show do |export|
     attributes_table do
-      row(:claim) do
-        div auto_link claim_export.claim.name, claim_export.claim_id
-      end
-      row(:pdf_file) do
-        div claim_export.pdf_file.filename unless claim_export.pdf_file_id.nil?
+      row(:resource) do
+        div auto_link export.resource.name, export.resource_id
       end
       row :in_progress
       row(:messages) do
-        claim_export.messages.map do |message|
+        export.messages.map do |message|
           div message
         end
       end

--- a/app/models/admin/export.rb
+++ b/app/models/admin/export.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 module Admin
-  class ClaimExport < ApplicationRecord
-    self.table_name = :claim_exports
-    belongs_to :claim
+  class Export < ApplicationRecord
+    self.table_name = :exports
+    belongs_to :resource, polymorphic: true
     belongs_to :pdf_file, class_name: 'Admin::UploadedFile', optional: true
   end
 end

--- a/app/policies/admin/export_policy.rb
+++ b/app/policies/admin/export_policy.rb
@@ -1,5 +1,5 @@
 module Admin
-  class ClaimExportPolicy < ApplicationPolicy
+  class ExportPolicy < ApplicationPolicy
     class Scope < Struct.new(:user, :scope)
       def resolve
         scope


### PR DESCRIPTION
The admin system has now had it's 'ClaimExport' renamed to 'Export' - as it is no longer specific to a claim