### PR TITLE
Feature/RST-1243

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,8 @@ end
 gem 'devise', '~> 4.4'
 gem 'activeadmin', '~> 1.2'
 gem 'activeadmin_addons', '~> 1.4'
+gem 'activerecord-import', '~> 0.17'
+gem 'active_admin_import', '~> 3.1'
 gem 'pundit', '~> 1.1'
 gem 'httparty', '~> 0.16.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_admin_import (3.1.0)
+      activeadmin (>= 1.0.0.pre2)
+      activerecord-import (~> 0.17.0)
+      rchardet (~> 1.6)
+      rubyzip (~> 1.2)
     activeadmin (1.3.0)
       arbre (>= 1.1.1)
       coffee-rails
@@ -51,6 +56,8 @@ GEM
       activemodel (= 5.1.6)
       activesupport (= 5.1.6)
       arel (~> 8.0)
+    activerecord-import (0.17.2)
+      activerecord (>= 3.2)
     activesupport (5.1.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -192,12 +199,14 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    rchardet (1.8.0)
     redis (4.0.1)
     require_all (1.5.0)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
     ruby_dep (1.5.0)
+    rubyzip (1.2.1)
     rufus-scheduler (3.5.0)
       fugit (~> 1.1, >= 1.1.1)
     sass (3.5.6)
@@ -264,8 +273,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_admin_import (~> 3.1)
   activeadmin (~> 1.2)
   activeadmin_addons (~> 1.4)
+  activerecord-import (~> 0.17)
   byebug
   coffee-rails (~> 4.2)
   devise (~> 4.4)

--- a/app/admin/admin_users.rb
+++ b/app/admin/admin_users.rb
@@ -1,10 +1,43 @@
 ActiveAdmin.register Admin::User, as: 'User' do
   permit_params :email, :password, :password_confirmation
+  before_batch_import = lambda do |importer|
+    boom!
+  end
+#  active_admin_import batch_size: 3, before_batch_import: before_batch_import
+
+  collection_action :import, method: :get do
+    authorize!(:import, active_admin_config.resource_class)
+    render
+  end
+
+  action_item :import, only: :index do
+    if authorized?(:import, active_admin_config.resource_class)
+      link_to(
+        'Import Users',
+        action: :import
+      )
+    end
+  end
+
+  collection_action :do_import, method: :post do
+    authorize!(:import, active_admin_config.resource_class)
+    _params = params.respond_to?(:to_unsafe_h) ? params.to_unsafe_h : params
+    params = ActiveSupport::HashWithIndifferentAccess.new _params
+    import_service = ::Admin::UsersImportService.new(tempfile: params[:user_import][:file].tempfile)
+    import_service.call
+    if import_service.errors.empty?
+      redirect_to admin_users_path
+    else
+      raise 'We had errors'
+    end
+  end
 
   index do
     selectable_column
     id_column
+    column :username
     column :email
+    column :department
     column :current_sign_in_at
     column :sign_in_count
     column :created_at
@@ -19,6 +52,8 @@ ActiveAdmin.register Admin::User, as: 'User' do
   form do |f|
     f.inputs do
       f.input :email
+      f.input :username
+      f.input :department
       f.input :password
       f.input :password_confirmation
       f.input :role_ids, as: :selected_list, label: 'Roles'

--- a/app/models/admin/user.rb
+++ b/app/models/admin/user.rb
@@ -1,6 +1,7 @@
 module Admin
   class User < ApplicationRecord
     self.table_name = :admin_users
+    attribute :role_names, :string
     # Include default devise modules. Others available are:
     # :confirmable, :lockable, :timeoutable and :omniauthable
     devise :database_authenticatable,
@@ -11,6 +12,7 @@ module Admin
     has_many :permissions, class_name: 'Admin::Permission', through: :roles
 
     before_save :cache_permissions
+
 
     private
 

--- a/app/models/admin/user.rb
+++ b/app/models/admin/user.rb
@@ -1,7 +1,6 @@
 module Admin
   class User < ApplicationRecord
     self.table_name = :admin_users
-    attribute :role_names, :string
     # Include default devise modules. Others available are:
     # :confirmable, :lockable, :timeoutable and :omniauthable
     devise :database_authenticatable,

--- a/app/policies/admin/acas_certificate_form_policy.rb
+++ b/app/policies/admin/acas_certificate_form_policy.rb
@@ -8,11 +8,11 @@ module Admin
     end
 
     def show?
-      true
+      user.is_admin? || user.permission_names.include?('read_acas')
     end
 
     def index?
-      true
+      false
     end
 
     def update?

--- a/app/policies/admin/address_policy.rb
+++ b/app/policies/admin/address_policy.rb
@@ -18,7 +18,7 @@ module Admin
       user.is_admin? || user.permission_names.include?('edit_addresses')
     end
 
-    def destroy
+    def destroy?
       user.is_admin? || user.permission_names.include?('delete_addresses')
     end
   end

--- a/app/policies/admin/address_policy.rb
+++ b/app/policies/admin/address_policy.rb
@@ -4,18 +4,22 @@ module Admin
       def resolve
         scope
       end
-
     end
+
     def index?
-      true
+      user.is_admin? || user.permission_names.include?('read_addresses')
+    end
+
+    def show?
+      user.is_admin? || user.permission_names.include?('read_addresses')
     end
 
     def update?
-      false
+      user.is_admin? || user.permission_names.include?('edit_addresses')
     end
 
     def destroy
-      false
+      user.is_admin? || user.permission_names.include?('delete_addresses')
     end
   end
 

--- a/app/policies/admin/atos_file_policy.rb
+++ b/app/policies/admin/atos_file_policy.rb
@@ -8,15 +8,15 @@ module Admin
     end
 
     def show?
-      true
+      user.is_admin? || user.permission_names.include?('read_atos_files')
     end
 
     def download?
-      true
+      user.is_admin? || user.permission_names.include?('read_atos_files')
     end
 
     def index?
-      true
+      user.is_admin? || user.permission_names.include?('read_atos_files')
     end
 
     def update?
@@ -24,7 +24,7 @@ module Admin
     end
 
     def destroy
-      false
+      user.is_admin? || user.permission_names.include?('delete_atos_files')
     end
   end
 

--- a/app/policies/admin/atos_file_policy.rb
+++ b/app/policies/admin/atos_file_policy.rb
@@ -27,5 +27,4 @@ module Admin
       user.is_admin? || user.permission_names.include?('delete_atos_files')
     end
   end
-
 end

--- a/app/policies/admin/claim_policy.rb
+++ b/app/policies/admin/claim_policy.rb
@@ -4,18 +4,22 @@ module Admin
       def resolve
         scope
       end
-
     end
+
     def index?
-      true
+      user.is_admin? || user.permission_names.include?('read_claims')
+    end
+
+    def show?
+      user.is_admin? || user.permission_names.include?('read_claims')
     end
 
     def update?
-      false
+      user.is_admin? || user.permission_names.include?('update_claims')
     end
 
     def destroy
-      false
+      user.is_admin? || user.permission_names.include?('delete_claims')
     end
   end
 

--- a/app/policies/admin/claimant_policy.rb
+++ b/app/policies/admin/claimant_policy.rb
@@ -4,18 +4,22 @@ module Admin
       def resolve
         scope
       end
-
     end
+
     def index?
-      true
+      user.is_admin? || user.permission_names.include?('read_claimants')
+    end
+
+    def show?
+      user.is_admin? || user.permission_names.include?('read_claimants')
     end
 
     def update?
-      false
+      user.is_admin? || user.permission_names.include?('update_claimants')
     end
 
     def destroy
-      false
+      user.is_admin? || user.permission_names.include?('delete_claimants')
     end
   end
 

--- a/app/policies/admin/export_policy.rb
+++ b/app/policies/admin/export_policy.rb
@@ -7,15 +7,19 @@ module Admin
 
     end
     def index?
-      true
+      user.is_admin? || user.permission_names.include?('read_exports')
+    end
+
+    def show?
+      user.is_admin? || user.permission_names.include?('read_exports')
     end
 
     def update?
-      false
+      user.is_admin? || user.permission_names.include?('update_exports')
     end
 
     def destroy
-      false
+      user.is_admin? || user.permission_names.include?('delete_exports')
     end
   end
 

--- a/app/policies/admin/exported_file_policy.rb
+++ b/app/policies/admin/exported_file_policy.rb
@@ -7,15 +7,19 @@ module Admin
 
     end
     def index?
-      true
+      user.is_admin? || user.permission_names.include?('read_exported_files')
+    end
+
+    def show?
+      user.is_admin? || user.permission_names.include?('read_exported_files')
     end
 
     def update?
-      false
+      user.is_admin? || user.permission_names.include?('update_exported_files')
     end
 
     def destroy
-      false
+      user.is_admin? || user.permission_names.include?('delete_exported_files')
     end
   end
 

--- a/app/policies/admin/office_policy.rb
+++ b/app/policies/admin/office_policy.rb
@@ -1,11 +1,20 @@
 module Admin
   class OfficePolicy < ApplicationPolicy
     def index?
-      true
+      user.is_admin? || user.permission_names.include?('read_offices')
     end
 
     def show?
-      false
+      user.is_admin? || user.permission_names.include?('read_offices')
     end
+
+    def update?
+      user.is_admin? || user.permission_names.include?('update_offices')
+    end
+
+    def destroy
+      user.is_admin? || user.permission_names.include?('delete_offices')
+    end
+
   end
 end

--- a/app/policies/admin/office_policy.rb
+++ b/app/policies/admin/office_policy.rb
@@ -1,5 +1,9 @@
 module Admin
   class OfficePolicy < ApplicationPolicy
+    def create?
+      user.is_admin? || user.permission_names.include?('create_offices')
+    end
+
     def index?
       user.is_admin? || user.permission_names.include?('read_offices')
     end

--- a/app/policies/admin/permission_policy.rb
+++ b/app/policies/admin/permission_policy.rb
@@ -6,6 +6,10 @@ module Admin
       end
     end
 
+    def create?
+      user.is_admin?
+    end
+
     def index?
       user.is_admin?
     end

--- a/app/policies/admin/permission_policy.rb
+++ b/app/policies/admin/permission_policy.rb
@@ -18,7 +18,7 @@ module Admin
       user.is_admin?
     end
 
-    def delete?
+    def destroy?
       user.is_admin?
     end
   end

--- a/app/policies/admin/permission_policy.rb
+++ b/app/policies/admin/permission_policy.rb
@@ -7,11 +7,19 @@ module Admin
     end
 
     def index?
-      true
+      user.is_admin?
     end
 
     def show?
-      true
+      user.is_admin?
+    end
+
+    def update?
+      user.is_admin?
+    end
+
+    def delete?
+      user.is_admin?
     end
   end
 end

--- a/app/policies/admin/representative_policy.rb
+++ b/app/policies/admin/representative_policy.rb
@@ -7,15 +7,19 @@ module Admin
 
     end
     def index?
-      true
+      user.is_admin? || user.permission_names.include?('read_representatives')
+    end
+
+    def show?
+      user.is_admin? || user.permission_names.include?('read_representatives')
     end
 
     def update?
-      false
+      user.is_admin? || user.permission_names.include?('update_representatives')
     end
 
     def destroy
-      false
+      user.is_admin? || user.permission_names.include?('delete_representatives')
     end
   end
 

--- a/app/policies/admin/respondent_policy.rb
+++ b/app/policies/admin/respondent_policy.rb
@@ -7,15 +7,19 @@ module Admin
 
     end
     def index?
-      true
+      user.is_admin? || user.permission_names.include?('read_respondent')
+    end
+
+    def show?
+      user.is_admin? || user.permission_names.include?('read_respondent')
     end
 
     def update?
-      false
+      user.is_admin? || user.permission_names.include?('update_respondent')
     end
 
     def destroy
-      false
+      user.is_admin? || user.permission_names.include?('delete_respondent')
     end
   end
 

--- a/app/policies/admin/role_policy.rb
+++ b/app/policies/admin/role_policy.rb
@@ -6,6 +6,10 @@ module Admin
       end
     end
 
+    def create?
+      user.is_admin?
+    end
+
     def show?
       user.is_admin?
     end

--- a/app/policies/admin/role_policy.rb
+++ b/app/policies/admin/role_policy.rb
@@ -18,7 +18,7 @@ module Admin
       user.is_admin?
     end
 
-    def delete?
+    def destroy?
       user.is_admin?
     end
   end

--- a/app/policies/admin/role_policy.rb
+++ b/app/policies/admin/role_policy.rb
@@ -7,14 +7,18 @@ module Admin
     end
 
     def show?
-      true
+      user.is_admin?
     end
 
     def index?
-      true
+      user.is_admin?
     end
 
     def update?
+      user.is_admin?
+    end
+
+    def delete?
       user.is_admin?
     end
   end

--- a/app/policies/admin/uploaded_file_policy.rb
+++ b/app/policies/admin/uploaded_file_policy.rb
@@ -4,18 +4,22 @@ module Admin
       def resolve
         scope
       end
-
     end
+
     def index?
-      true
+      user.is_admin? || user.permission_names.include?('read_uploaded_file')
+    end
+
+    def show?
+      user.is_admin? || user.permission_names.include?('read_uploaded_file')
     end
 
     def update?
-      false
+      user.is_admin? || user.permission_names.include?('update_uploaded_file')
     end
 
-    def destroy
-      false
+    def delete?
+      user.is_admin? || user.permission_names.include?('delete_uploaded_file')
     end
   end
 

--- a/app/policies/admin/uploaded_file_policy.rb
+++ b/app/policies/admin/uploaded_file_policy.rb
@@ -18,7 +18,7 @@ module Admin
       user.is_admin? || user.permission_names.include?('update_uploaded_file')
     end
 
-    def delete?
+    def destroy?
       user.is_admin? || user.permission_names.include?('delete_uploaded_file')
     end
   end

--- a/app/policies/admin/user_policy.rb
+++ b/app/policies/admin/user_policy.rb
@@ -6,6 +6,10 @@ module Admin
       end
     end
 
+    def create?
+      user.is_admin? || user.permission_names.include?('create_users')
+    end
+
     def index?
       user.is_admin? || user.permission_names.include?('read_users')
     end
@@ -20,6 +24,10 @@ module Admin
 
     def destroy?
       user.is_admin? || user.permission_names.include?('delete_users')
+    end
+
+    def import?
+      user.is_admin? || user.permission_names.include?('import_users')
     end
   end
 end

--- a/app/policies/admin/user_policy.rb
+++ b/app/policies/admin/user_policy.rb
@@ -18,7 +18,7 @@ module Admin
       user.is_admin? || user.permission_names.include?('update_users')
     end
 
-    def delete?
+    def destroy?
       user.is_admin? || user.permission_names.include?('delete_users')
     end
   end

--- a/app/policies/admin/user_policy.rb
+++ b/app/policies/admin/user_policy.rb
@@ -1,21 +1,25 @@
 module Admin
   class UserPolicy < ApplicationPolicy
-    def index?
-      user.is_admin?
-    end
-
     class Scope < Struct.new(:user, :scope)
       def resolve
         scope
       end
     end
 
+    def index?
+      user.is_admin? || user.permission_names.include?('read_users')
+    end
+
     def show?
-      true
+      user.is_admin? || user.permission_names.include?('read_users')
     end
 
     def update?
-      user.is_admin?
+      user.is_admin? || user.permission_names.include?('update_users')
+    end
+
+    def delete?
+      user.is_admin? || user.permission_names.include?('delete_users')
     end
   end
 end

--- a/app/services/admin/users_import_service.rb
+++ b/app/services/admin/users_import_service.rb
@@ -1,0 +1,71 @@
+module Admin
+  class UsersImportService
+    include ActiveModel::Model
+    attr_accessor :tempfile
+
+    def initialize(*)
+      super
+      self.batch_size = 100
+      initialize_role_cache
+    end
+
+    def call
+      import_csv
+    end
+
+    private
+
+    attr_accessor :role_cache, :batch_size
+
+    def initialize_role_cache
+      self.role_cache = Hash.new do |hash, key|
+        Admin::Role.find_by(name: key).tap do |role|
+          hash[key] = role
+          raise "Unknown role #{key}" unless role.present?
+        end
+      end
+    end
+
+    def import_csv
+      lines = tempfile.readlines("\n").map { |l| l.gsub(/\n\z/, '').gsub(/\r\z/, '') }
+      rows = CSV.parse(lines.join("\n"), headers: true)
+      User.transaction do
+        begin
+          import_in_batches(rows)
+        rescue ActiveRecord::RecordInvalid => ex
+          errors.add(:tempfile, "Line #{idx + 1} - #{ex.message}")
+        end
+      end
+    end
+
+    def normalize_row(row)
+      {
+        username: row['username'],
+        name: row['name'],
+        email: row['email'],
+        password: row['password'],
+        password_confirmation: row['password'],
+        department: row['department'],
+        roles: [role_with_name(row['Role'].strip.titleize)]
+      }
+    end
+
+    def import_in_batches(rows)
+      rows.each_slice(batch_size) do |rows|
+        User.import import_rows(rows)
+      end
+    end
+
+    def import_rows(rows)
+      batch = []
+      rows.each do |row|
+        batch << User.new(normalize_row(row))
+      end
+      batch
+    end
+
+    def role_with_name(name)
+      role_cache[name]
+    end
+  end
+end

--- a/app/views/admin/users/import.html.erb
+++ b/app/views/admin/users/import.html.erb
@@ -1,0 +1,8 @@
+<%= semantic_form_for :user_import, url: {action: :do_import}, html: {multipart: true} do |f| %>
+    <%= f.inputs name: 'Import File' do %>
+        <%= f.input :file, as: :file %>
+    <% end %>
+    <%= f.actions do %>
+        <%= f.action :submit, label: 'Import' %>
+    <% end %>
+<% end %>

--- a/app/views/admin/users/import.html.erb
+++ b/app/views/admin/users/import.html.erb
@@ -1,4 +1,7 @@
-<%= semantic_form_for :user_import, url: {action: :do_import}, html: {multipart: true} do |f| %>
+<% if @import_service.errors.present? %>
+<%= @import_service.errors.messages[:tempfile].join(' - ') %>
+<% end %>
+<%= semantic_form_for @import_service, url: {action: :do_import}, html: {multipart: true} do |f| %>
     <%= f.inputs name: 'Import File' do %>
         <%= f.input :file, as: :file %>
     <% end %>

--- a/app/views/admin/users/import.html.erb
+++ b/app/views/admin/users/import.html.erb
@@ -1,5 +1,7 @@
 <% if @import_service.errors.present? %>
-<%= @import_service.errors.messages[:tempfile].join(' - ') %>
+<% @import_service.errors.messages[:tempfile].each do |msg| %>
+    <p class="error"><%= msg %></p>
+<% end %>
 <% end %>
 <%= semantic_form_for @import_service, url: {action: :do_import}, html: {multipart: true} do |f| %>
     <%= f.inputs name: 'Import File' do %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -40,7 +40,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
+  config.authentication_keys = [:username]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-controlled_resources = [:offices, :jobs, :acas, :acas_download_logs, :addresses, :atos_files]
+controlled_resources = [:offices, :jobs, :acas, :acas_download_logs, :addresses, :atos_files, :claims]
 permissions = [:create, :read, :update, :delete].product(controlled_resources).map {|pair| pair.join('_')}.sort
 
 permissions.each do |p|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@
 
 controlled_resources = [:offices, :jobs, :acas, :acas_download_logs,
   :addresses, :atos_files, :claims, :claimants, :exports, :exported_files,
-  :representatives, :respondents]
+  :representatives, :respondents, :uploaded_files, :users]
 permissions = [:create, :read, :update, :delete].product(controlled_resources).map { |pair| pair.join('_') }.sort
 
 permissions.each do |p|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,130 +16,49 @@ permissions.each do |p|
   Admin::Permission.find_or_create_by! name: p
 end
 
-admin_role = Admin::Role.find_or_create_by(name: 'Admin') do |role|
-  role.is_admin = true
-end
-
-super_user_role = Admin::Role.find_or_create_by!(name: 'Super User') do |role|
-  role.permissions << Admin::Permission.find_by(name: 'read_offices')
-  role.permissions << Admin::Permission.find_by(name: 'update_offices')
-  role.permissions << Admin::Permission.find_by(name: 'delete_offices')
-  role.permissions << Admin::Permission.find_by(name: 'create_offices')
-  role.permissions << Admin::Permission.find_by(name: 'read_acas')
-  role.permissions << Admin::Permission.find_by(name: 'read_acas_download_logs')
-  role.permissions << Admin::Permission.find_by(name: 'read_acas_check_digits')
-  role.permissions << Admin::Permission.find_by(name: 'read_reference_number_generators')
-  role.permissions << Admin::Permission.find_by(name: 'create_reference_number_generators')
-
-  role.permissions << Admin::Permission.find_by(name: 'read_claims')
-  role.permissions << Admin::Permission.find_by(name: 'update_claims')
-  role.permissions << Admin::Permission.find_by(name: 'delete_claims')
-  role.permissions << Admin::Permission.find_by(name: 'create_claims')
-
-  role.permissions << Admin::Permission.find_by(name: 'read_responses')
-  role.permissions << Admin::Permission.find_by(name: 'update_responses')
-  role.permissions << Admin::Permission.find_by(name: 'delete_responses')
-  role.permissions << Admin::Permission.find_by(name: 'create_responses')
-
-  role.permissions << Admin::Permission.find_by(name: 'read_users')
-  role.permissions << Admin::Permission.find_by(name: 'update_users')
-  role.permissions << Admin::Permission.find_by(name: 'delete_users')
-  role.permissions << Admin::Permission.find_by(name: 'create_users')
-end
-
-developer_role = Admin::Role.find_or_create_by!(name: 'Developer') do |role|
-  role.permissions << Admin::Permission.find_by(name: 'read_offices')
-  role.permissions << Admin::Permission.find_by(name: 'update_offices')
-  role.permissions << Admin::Permission.find_by(name: 'delete_offices')
-  role.permissions << Admin::Permission.find_by(name: 'create_offices')
-
-  role.permissions << Admin::Permission.find_by(name: 'read_addresses')
-  role.permissions << Admin::Permission.find_by(name: 'update_addresses')
-  role.permissions << Admin::Permission.find_by(name: 'delete_addresses')
-  role.permissions << Admin::Permission.find_by(name: 'create_addresses')
-
-  role.permissions << Admin::Permission.find_by(name: 'read_claims')
-  role.permissions << Admin::Permission.find_by(name: 'update_claims')
-  role.permissions << Admin::Permission.find_by(name: 'delete_claims')
-  role.permissions << Admin::Permission.find_by(name: 'create_claims')
-
-  role.permissions << Admin::Permission.find_by(name: 'read_responses')
-  role.permissions << Admin::Permission.find_by(name: 'update_responses')
-  role.permissions << Admin::Permission.find_by(name: 'delete_responses')
-  role.permissions << Admin::Permission.find_by(name: 'create_responses')
-
-  role.permissions << Admin::Permission.find_by(name: 'read_claimants')
-  role.permissions << Admin::Permission.find_by(name: 'update_claimants')
-  role.permissions << Admin::Permission.find_by(name: 'delete_claimants')
-  role.permissions << Admin::Permission.find_by(name: 'create_claimants')
-
-  role.permissions << Admin::Permission.find_by(name: 'read_representatives')
-  role.permissions << Admin::Permission.find_by(name: 'update_representatives')
-  role.permissions << Admin::Permission.find_by(name: 'delete_representatives')
-  role.permissions << Admin::Permission.find_by(name: 'create_representatives')
-
-  role.permissions << Admin::Permission.find_by(name: 'read_respondents')
-  role.permissions << Admin::Permission.find_by(name: 'update_respondents')
-  role.permissions << Admin::Permission.find_by(name: 'delete_respondents')
-  role.permissions << Admin::Permission.find_by(name: 'create_respondents')
-
-  role.permissions << Admin::Permission.find_by(name: 'read_uploaded_files')
-  role.permissions << Admin::Permission.find_by(name: 'update_uploaded_files')
-  role.permissions << Admin::Permission.find_by(name: 'delete_uploaded_files')
-  role.permissions << Admin::Permission.find_by(name: 'create_uploaded_files')
-
-  role.permissions << Admin::Permission.find_by(name: 'read_atos_files')
-
-
-  role.permissions << Admin::Permission.find_by(name: 'read_acas')
-  role.permissions << Admin::Permission.find_by(name: 'read_acas_download_logs')
-  role.permissions << Admin::Permission.find_by(name: 'read_acas_check_digits')
-  role.permissions << Admin::Permission.find_by(name: 'read_jobs')
-  role.permissions << Admin::Permission.find_by(name: 'read_reference_number_generators')
-  role.permissions << Admin::Permission.find_by(name: 'create_reference_number_generators')
-end
-
-user_role = Admin::Role.find_or_create_by!(name: 'User') do |role|
-  role.permissions << Admin::Permission.find_by(name: 'read_offices')
-  role.permissions << Admin::Permission.find_by(name: 'read_acas_download_logs')
-  role.permissions << Admin::Permission.find_by(name: 'read_acas')
-  role.permissions << Admin::Permission.find_by(name: 'read_acas_check_digits')
-  role.permissions << Admin::Permission.find_by(name: 'read_reference_number_generators')
-  role.permissions << Admin::Permission.find_by(name: 'create_reference_number_generators')
-end
+admin_role = Admin::Role.find_by(name: 'Admin')
+super_user_role = Admin::Role.find_by!(name: 'Super User')
+developer_role = Admin::Role.find_by!(name: 'Developer')
+user_role = Admin::Role.find_by!(name: 'User')
 
 
 if Rails.env.development? || ENV.fetch('SEED_EXAMPLE_USERS', 'false') == 'true'
   Admin::User.find_or_create_by!(email: 'admin@example.com') do |user|
+    user.username = 'admin'
     user.password = 'password'
     user.password_confirmation = 'password'
     user.roles << admin_role unless user.roles.include?(admin_role)
   end
 
   Admin::User.find_or_create_by!(email: 'developer@example.com') do |user|
+    user.username = 'developer'
     user.password = 'password'
     user.password_confirmation = 'password'
     user.roles << developer_role unless user.roles.include?(developer_role)
   end
 
   Admin::User.find_or_create_by!(email: 'senioruser@example.com') do |user|
+    user.username = 'senioruser'
     user.password = 'password'
     user.password_confirmation = 'password'
     user.roles << super_user_role unless user.roles.include?(super_user_role)
   end
 
   Admin::User.find_or_create_by!(email: 'superuser@example.com') do |user|
+    user.username = 'superuser'
     user.password = 'password'
     user.password_confirmation = 'password'
     user.roles << super_user_role unless user.roles.include?(super_user_role)
   end
 
   Admin::User.find_or_create_by!(email: 'junioruser@example.com') do |user|
+    user.username = 'junioruser'
     user.password = 'password'
     user.password_confirmation = 'password'
     user.roles << user_role unless user.roles.include?(user_role)
   end
   Admin::User.find_or_create_by!(email: 'user@example.com') do |user|
+    user.username = 'user'
     user.password = 'password'
     user.password_confirmation = 'password'
     user.roles << user_role unless user.roles.include?(user_role)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,28 +8,104 @@
 
 controlled_resources = [:offices, :jobs, :acas, :acas_download_logs,
   :addresses, :atos_files, :claims, :claimants, :exports, :exported_files,
-  :representatives, :respondents, :uploaded_files, :users]
-permissions = [:create, :read, :update, :delete].product(controlled_resources).map { |pair| pair.join('_') }.sort
+  :representatives, :respondents, :responses, :uploaded_files, :users, :acas_check_digits,
+  :reference_number_generators]
+permissions = [:create, :read, :update, :delete, :import].product(controlled_resources).map { |pair| pair.join('_') }.sort
 
 permissions.each do |p|
   Admin::Permission.find_or_create_by! name: p
 end
 
-admin_role = Admin::Role.find_or_create_by(name: 'administrator') do |role|
+admin_role = Admin::Role.find_or_create_by(name: 'Admin') do |role|
   role.is_admin = true
 end
 
-senior_role = Admin::Role.find_or_create_by!(name: 'senior') do |role|
+super_user_role = Admin::Role.find_or_create_by!(name: 'Super User') do |role|
   role.permissions << Admin::Permission.find_by(name: 'read_offices')
   role.permissions << Admin::Permission.find_by(name: 'update_offices')
   role.permissions << Admin::Permission.find_by(name: 'delete_offices')
   role.permissions << Admin::Permission.find_by(name: 'create_offices')
   role.permissions << Admin::Permission.find_by(name: 'read_acas')
+  role.permissions << Admin::Permission.find_by(name: 'read_acas_download_logs')
+  role.permissions << Admin::Permission.find_by(name: 'read_acas_check_digits')
+  role.permissions << Admin::Permission.find_by(name: 'read_reference_number_generators')
+  role.permissions << Admin::Permission.find_by(name: 'create_reference_number_generators')
+
+  role.permissions << Admin::Permission.find_by(name: 'read_claims')
+  role.permissions << Admin::Permission.find_by(name: 'update_claims')
+  role.permissions << Admin::Permission.find_by(name: 'delete_claims')
+  role.permissions << Admin::Permission.find_by(name: 'create_claims')
+
+  role.permissions << Admin::Permission.find_by(name: 'read_responses')
+  role.permissions << Admin::Permission.find_by(name: 'update_responses')
+  role.permissions << Admin::Permission.find_by(name: 'delete_responses')
+  role.permissions << Admin::Permission.find_by(name: 'create_responses')
+
+  role.permissions << Admin::Permission.find_by(name: 'read_users')
+  role.permissions << Admin::Permission.find_by(name: 'update_users')
+  role.permissions << Admin::Permission.find_by(name: 'delete_users')
+  role.permissions << Admin::Permission.find_by(name: 'create_users')
 end
 
-junior_role = Admin::Role.find_or_create_by!(name: 'junior') do |role|
+developer_role = Admin::Role.find_or_create_by!(name: 'Developer') do |role|
   role.permissions << Admin::Permission.find_by(name: 'read_offices')
+  role.permissions << Admin::Permission.find_by(name: 'update_offices')
+  role.permissions << Admin::Permission.find_by(name: 'delete_offices')
+  role.permissions << Admin::Permission.find_by(name: 'create_offices')
+
+  role.permissions << Admin::Permission.find_by(name: 'read_addresses')
+  role.permissions << Admin::Permission.find_by(name: 'update_addresses')
+  role.permissions << Admin::Permission.find_by(name: 'delete_addresses')
+  role.permissions << Admin::Permission.find_by(name: 'create_addresses')
+
+  role.permissions << Admin::Permission.find_by(name: 'read_claims')
+  role.permissions << Admin::Permission.find_by(name: 'update_claims')
+  role.permissions << Admin::Permission.find_by(name: 'delete_claims')
+  role.permissions << Admin::Permission.find_by(name: 'create_claims')
+
+  role.permissions << Admin::Permission.find_by(name: 'read_responses')
+  role.permissions << Admin::Permission.find_by(name: 'update_responses')
+  role.permissions << Admin::Permission.find_by(name: 'delete_responses')
+  role.permissions << Admin::Permission.find_by(name: 'create_responses')
+
+  role.permissions << Admin::Permission.find_by(name: 'read_claimants')
+  role.permissions << Admin::Permission.find_by(name: 'update_claimants')
+  role.permissions << Admin::Permission.find_by(name: 'delete_claimants')
+  role.permissions << Admin::Permission.find_by(name: 'create_claimants')
+
+  role.permissions << Admin::Permission.find_by(name: 'read_representatives')
+  role.permissions << Admin::Permission.find_by(name: 'update_representatives')
+  role.permissions << Admin::Permission.find_by(name: 'delete_representatives')
+  role.permissions << Admin::Permission.find_by(name: 'create_representatives')
+
+  role.permissions << Admin::Permission.find_by(name: 'read_respondents')
+  role.permissions << Admin::Permission.find_by(name: 'update_respondents')
+  role.permissions << Admin::Permission.find_by(name: 'delete_respondents')
+  role.permissions << Admin::Permission.find_by(name: 'create_respondents')
+
+  role.permissions << Admin::Permission.find_by(name: 'read_uploaded_files')
+  role.permissions << Admin::Permission.find_by(name: 'update_uploaded_files')
+  role.permissions << Admin::Permission.find_by(name: 'delete_uploaded_files')
+  role.permissions << Admin::Permission.find_by(name: 'create_uploaded_files')
+
+  role.permissions << Admin::Permission.find_by(name: 'read_atos_files')
+
+
   role.permissions << Admin::Permission.find_by(name: 'read_acas')
+  role.permissions << Admin::Permission.find_by(name: 'read_acas_download_logs')
+  role.permissions << Admin::Permission.find_by(name: 'read_acas_check_digits')
+  role.permissions << Admin::Permission.find_by(name: 'read_jobs')
+  role.permissions << Admin::Permission.find_by(name: 'read_reference_number_generators')
+  role.permissions << Admin::Permission.find_by(name: 'create_reference_number_generators')
+end
+
+user_role = Admin::Role.find_or_create_by!(name: 'User') do |role|
+  role.permissions << Admin::Permission.find_by(name: 'read_offices')
+  role.permissions << Admin::Permission.find_by(name: 'read_acas_download_logs')
+  role.permissions << Admin::Permission.find_by(name: 'read_acas')
+  role.permissions << Admin::Permission.find_by(name: 'read_acas_check_digits')
+  role.permissions << Admin::Permission.find_by(name: 'read_reference_number_generators')
+  role.permissions << Admin::Permission.find_by(name: 'create_reference_number_generators')
 end
 
 
@@ -40,15 +116,32 @@ if Rails.env.development? || ENV.fetch('SEED_EXAMPLE_USERS', 'false') == 'true'
     user.roles << admin_role unless user.roles.include?(admin_role)
   end
 
+  Admin::User.find_or_create_by!(email: 'developer@example.com') do |user|
+    user.password = 'password'
+    user.password_confirmation = 'password'
+    user.roles << developer_role unless user.roles.include?(developer_role)
+  end
+
   Admin::User.find_or_create_by!(email: 'senioruser@example.com') do |user|
     user.password = 'password'
     user.password_confirmation = 'password'
-    user.roles << senior_role unless user.roles.include?(senior_role)
+    user.roles << super_user_role unless user.roles.include?(super_user_role)
+  end
+
+  Admin::User.find_or_create_by!(email: 'superuser@example.com') do |user|
+    user.password = 'password'
+    user.password_confirmation = 'password'
+    user.roles << super_user_role unless user.roles.include?(super_user_role)
   end
 
   Admin::User.find_or_create_by!(email: 'junioruser@example.com') do |user|
     user.password = 'password'
     user.password_confirmation = 'password'
-    user.roles << junior_role unless user.roles.include?(junior_role)
+    user.roles << user_role unless user.roles.include?(user_role)
+  end
+  Admin::User.find_or_create_by!(email: 'user@example.com') do |user|
+    user.password = 'password'
+    user.password_confirmation = 'password'
+    user.roles << user_role unless user.roles.include?(user_role)
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,8 +6,10 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-controlled_resources = [:offices, :jobs, :acas, :acas_download_logs, :addresses, :atos_files, :claims, :claimants, :exports, :exported_files]
-permissions = [:create, :read, :update, :delete].product(controlled_resources).map {|pair| pair.join('_')}.sort
+controlled_resources = [:offices, :jobs, :acas, :acas_download_logs,
+  :addresses, :atos_files, :claims, :claimants, :exports, :exported_files,
+  :representatives]
+permissions = [:create, :read, :update, :delete].product(controlled_resources).map { |pair| pair.join('_') }.sort
 
 permissions.each do |p|
   Admin::Permission.find_or_create_by! name: p

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@
 
 controlled_resources = [:offices, :jobs, :acas, :acas_download_logs,
   :addresses, :atos_files, :claims, :claimants, :exports, :exported_files,
-  :representatives]
+  :representatives, :respondents]
 permissions = [:create, :read, :update, :delete].product(controlled_resources).map { |pair| pair.join('_') }.sort
 
 permissions.each do |p|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-controlled_resources = [:offices, :jobs, :acas, :acas_download_logs, :addresses]
+controlled_resources = [:offices, :jobs, :acas, :acas_download_logs, :addresses, :atos_files]
 permissions = [:create, :read, :update, :delete].product(controlled_resources).map {|pair| pair.join('_')}.sort
 
 permissions.each do |p|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-controlled_resources = [:offices, :jobs, :acas, :acas_download_logs]
+controlled_resources = [:offices, :jobs, :acas, :acas_download_logs, :addresses]
 permissions = [:create, :read, :update, :delete].product(controlled_resources).map {|pair| pair.join('_')}.sort
 
 permissions.each do |p|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-controlled_resources = [:offices, :jobs, :acas, :acas_download_logs, :addresses, :atos_files, :claims, :claimants]
+controlled_resources = [:offices, :jobs, :acas, :acas_download_logs, :addresses, :atos_files, :claims, :claimants, :exports, :exported_files]
 permissions = [:create, :read, :update, :delete].product(controlled_resources).map {|pair| pair.join('_')}.sort
 
 permissions.each do |p|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-controlled_resources = [:offices, :jobs, :acas]
+controlled_resources = [:offices, :jobs, :acas, :acas_download_logs]
 permissions = [:create, :read, :update, :delete].product(controlled_resources).map {|pair| pair.join('_')}.sort
 
 permissions.each do |p|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-controlled_resources = [:offices, :jobs, :acas, :acas_download_logs, :addresses, :atos_files, :claims]
+controlled_resources = [:offices, :jobs, :acas, :acas_download_logs, :addresses, :atos_files, :claims, :claimants]
 permissions = [:create, :read, :update, :delete].product(controlled_resources).map {|pair| pair.join('_')}.sort
 
 permissions.each do |p|


### PR DESCRIPTION
**ADMIN: Create Roles for Admin Functions**


User - Typical day-to-day ET Admin functions, ACAS certificate download and view Office Postcode coverage definitions

                    
Super User - Extended access from the User role to allow viewing of the online Claim and Response forms and to maintain the Office Postcode coverage definitions.

                   
Admin - Provide access to all ET admin functions including add/remove users and user role maintenance.   

 

Please can this work be done in the seeds.rb, being written in a way that the seed task can be ran multiple times and it will ensure that the data is correct.  This will allow the test suite to use the same data and will also allow all environments to keep production like role data