### PR TITLE
Upgraded sprockets due to CVE-2018-3760 security issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,7 +235,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -299,4 +299,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.1
+   1.16.3


### PR DESCRIPTION
Upgraded sprockets due to CVE-2018-3760 security issue