### PR TITLE
Configure claim to show the primary claimant

### DIFF
--- a/app/admin/admin_claims.rb
+++ b/app/admin/admin_claims.rb
@@ -14,6 +14,7 @@ ActiveAdmin.register Admin::Claim, as: 'Claims' do
   index do
     selectable_column
     id_column
+    column :name
     column :reference
   end
 
@@ -22,7 +23,8 @@ ActiveAdmin.register Admin::Claim, as: 'Claims' do
       f.input :reference
       f.input :submission_reference
       f.input :submission_channel
-      f.input :claimant_ids, as: :selected_list, label: 'Claimants'
+      f.input :primary_claimant, member_label: Proc.new { |c| "#{c.first_name} #{c.last_name}" }
+      f.input :secondary_claimant_ids, as: :selected_list, label: 'Claimants'
     end
     f.actions
   end
@@ -30,7 +32,7 @@ ActiveAdmin.register Admin::Claim, as: 'Claims' do
   show do |claim|
     default_attribute_table_rows = active_admin_config.resource_columns
     attributes_table(*default_attribute_table_rows)
-    panel('Claimants') do
+    panel('Secondary Claimants') do
       table_for claim.claimants do
         column(:id) { |r| auto_link r, r.id }
         column :title

--- a/app/models/admin/claim.rb
+++ b/app/models/admin/claim.rb
@@ -9,10 +9,7 @@ module Admin
     has_many :respondents, through: :claim_respondents
     has_many :representatives, through: :claim_representatives
     has_many :uploaded_files, through: :claim_uploaded_files
-
-    def primary_claimant
-      claimants.first
-    end
+    belongs_to :primary_claimant, class_name: 'Admin::Claimant'
 
     def name
       claimant = primary_claimant


### PR DESCRIPTION
This PR allows  the admin user to see the primary claimant once the API PR (same branch name) has been deployed.

If this is deployed first, the 'claims' section will fail to show and errors will be logged