### PR TITLE
Rst 1344 office postcodes

### DIFF
--- a/app/admin/admin_office_post_codes.rb
+++ b/app/admin/admin_office_post_codes.rb
@@ -1,4 +1,4 @@
-ActiveAdmin.register OfficePostCode, as: 'Office Post Codes' do
+ActiveAdmin.register OfficePostCode, as: 'Office Postcodes' do
   actions :all
   config.batch_actions = false
 

--- a/app/models/office_post_code.rb
+++ b/app/models/office_post_code.rb
@@ -3,7 +3,8 @@ class OfficePostCode < ApplicationRecord
 
   belongs_to :office
 
-  validates :postcode, presence: true, uniqueness: true
+  validates :postcode, presence: true
+  validates_uniqueness_of :postcode, case_sensitive: false
 
   def to_s
     postcode


### PR DESCRIPTION
This PR fixes the postcodes spelling and changes the postcode uniqueness validation to case insensitive to avoid duplicates like `E1` and `e1`.