### PR TITLE
RST-1418: Enable users to add permissions

### DIFF
--- a/app/admin/admin_permissions.rb
+++ b/app/admin/admin_permissions.rb
@@ -12,4 +12,5 @@ ActiveAdmin.register Admin::Permission, as: 'Permissions' do
 #   permitted
 # end
 
+  permit_params :name
 end


### PR DESCRIPTION
...This was easier than I thought. When we attempted to add permissions via the admin portal we were given an attribute forbidden error. I added the field to permitted params and it worked. Users with the correct policies in place can now CRUD permissions.