### PR TITLE
RST-1483: Extract employment_details Data

### DIFF
--- a/lib/tasks/extract_data.rake
+++ b/lib/tasks/extract_data.rake
@@ -20,7 +20,16 @@ namespace :extract_data do
         csv << hash.values
       end
     end
+  end
 
+  desc 'Prints the percentage of employment_details completed from all claims complete'
+  task employment_details_completion_rate: :environment do
+    include ActiveSupport::NumberHelper
+    number_completed = Claim.where(updated_at: 1.year.ago..Time.now)
+                            .where.not(employment_details: {}).count
+    total_completed = Claim.where(updated_at: 1.year.ago..Time.now).count
+
+    puts number_to_percentage(number_completed / total_completed, precision: 2)
   end
 
 end

--- a/lib/tasks/extract_data.rake
+++ b/lib/tasks/extract_data.rake
@@ -26,8 +26,8 @@ namespace :extract_data do
   task employment_details_completion_rate: :environment do
     include ActiveSupport::NumberHelper
     number_completed = Claim.where(updated_at: 1.year.ago..Time.now)
-                            .where.not(employment_details: {}).count
-    total_completed = Claim.where(updated_at: 1.year.ago..Time.now).count
+                            .where.not(employment_details: {}).count.to_f
+    total_completed = Claim.where(updated_at: 1.year.ago..Time.now).count.to_f
 
     puts number_to_percentage(number_completed / total_completed, precision: 2)
   end

--- a/lib/tasks/extract_data.rake
+++ b/lib/tasks/extract_data.rake
@@ -1,0 +1,6 @@
+namespace :extract_data do
+  desc "TODO"
+  task employment_details: :environment do
+  end
+
+end

--- a/lib/tasks/extract_data.rake
+++ b/lib/tasks/extract_data.rake
@@ -1,6 +1,26 @@
 namespace :extract_data do
-  desc "TODO"
+  desc 'Creates a CSV file with answers from pay, pension and benefits sections of the Employment Details section'
   task employment_details: :environment do
+    employment_details = []
+    Claim.where(updated_at: 1.year.ago..Time.now).each do |record|
+      next if record.employment_details.empty?
+      employment_details << record.employment_details.symbolize_keys
+                                  .slice(:net_pay,
+                                         :net_pay_period_type,
+                                         :gross_pay,
+                                         :gross_pay_period_type,
+                                         :enrolled_in_pension_scheme,
+                                         :benefit_details)
+    end
+
+    CSV.open('tmp/employment_details.csv', 'wb') do |csv|
+      keys = employment_details.first.keys
+      csv << keys
+      employment_details.each do |hash|
+        csv << hash.values
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
Adds a rake file with two tasks:

1. Prepares a CSV file (`tmp/employment_details.csv`) which contains `net_pay`, `net_pay_period_type`, `gross_pay`, `gross_pay_period_type`, `enrolled_in_pension_scheme` and `benefit_details` for all Claims where the employment_details section was completed.
2. Prints the percentage of employment_details completed from all claims completed
