### PR TITLE
RST-1553 Re model ET1 claim data

### DIFF
--- a/app/admin/admin_claims.rb
+++ b/app/admin/admin_claims.rb
@@ -33,7 +33,7 @@ ActiveAdmin.register Claim, as: 'Claims' do
     default_attribute_table_rows = active_admin_config.resource_columns
     attributes_table(*default_attribute_table_rows)
     panel('Secondary Claimants') do
-      table_for claim.claimants do
+      table_for claim.secondary_claimants do
         column(:id) { |r| auto_link r, r.id }
         column :title
         column :first_name
@@ -41,15 +41,15 @@ ActiveAdmin.register Claim, as: 'Claims' do
       end
     end
 
-    panel('Respondents') do
-      table_for claim.respondents do
+    panel('Secondary Respondents') do
+      table_for claim.secondary_respondents do
         column(:id) { |r| auto_link r, r.id }
         column :name
       end
     end
 
-    panel('Representatives') do
-      table_for claim.representatives do
+    panel('Secondary Representatives') do
+      table_for claim.secondary_representatives do
         column(:id) { |r| auto_link r, r.id }
         column(:name)
       end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -4,11 +4,13 @@ class Claim < ApplicationRecord
   has_many :claim_respondents
   has_many :claim_representatives
   has_many :claim_uploaded_files
-  has_many :claimants, through: :claim_claimants
-  has_many :respondents, through: :claim_respondents
-  has_many :representatives, through: :claim_representatives
+  has_many :secondary_claimants, through: :claim_claimants, class_name: 'Claimant', source: :claimant
+  has_many :secondary_respondents, through: :claim_respondents, class_name: 'Respondent', source: :respondent
+  has_many :secondary_representatives, through: :claim_representatives, class_name: 'Representative', source: :representative
   has_many :uploaded_files, through: :claim_uploaded_files
   belongs_to :primary_claimant, class_name: 'Claimant'
+  belongs_to :primary_respondent, class_name: 'Respondent', optional: true
+  belongs_to :primary_repesentative, class_name: 'Representative', optional: true
 
   def name
     claimant = primary_claimant


### PR DESCRIPTION
RST-1553 Re model ET1 claim data to support primary_respondent, secondary_respondent, primary_respondent

This PR is the admin side to this so that it knows how to display the primary respondents and reps