### PR TITLE
All association filters using drop down removed - RST-1621 ADMIN

### DIFF
--- a/app/admin/admin_claimants.rb
+++ b/app/admin/admin_claimants.rb
@@ -11,6 +11,10 @@ ActiveAdmin.register Claimant, as: 'Claimants' do
 #   permitted << :other if params[:action] == 'create' && current_user.admin?
 #   permitted
 # end
+
+  preserve_default_filters!
+  remove_filter :address
+
   show do |claimant|
     attributes_table do
       row :title

--- a/app/admin/admin_claims.rb
+++ b/app/admin/admin_claims.rb
@@ -11,6 +11,20 @@ ActiveAdmin.register Claim, as: 'Claims' do
 #   permitted << :other if params[:action] == 'create' && current_user.admin?
 #   permitted
 # end
+
+  preserve_default_filters!
+  remove_filter :claim_claimants, :claim_respondents, :claim_representatives, :claim_uploaded_files
+  remove_filter :secondary_claimants, :secondary_respondents, :secondary_representatives
+  remove_filter :uploaded_files, :primary_representative, :submission_channel, :jurisdiction
+  remove_filter :administrator, :created_at, :updated_at, :other_known_claimant_names
+  remove_filter :discrimination_claims, :pay_claims, :desired_outcomes, :other_claim_details
+  remove_filter :claim_details, :other_outcome, :send_claim_to_whistleblowing_entity
+  remove_filter :miscellaneous_information, :is_unfair_dismissal, :primary_claimant, :primary_respondent, :primary_representative
+  filter :primary_claimant_first_name_cont, label: "Primary claimant first name"
+  filter :primary_claimant_last_name_cont, label: "Primary claimant last name"
+  filter :primary_respondent_name_or_primary_respondent_contact_cont, label: 'Primary Respondent Name'
+
+
   index do
     selectable_column
     id_column

--- a/app/admin/admin_exports.rb
+++ b/app/admin/admin_exports.rb
@@ -11,6 +11,10 @@ ActiveAdmin.register Export, as: 'Exports' do
 #   permitted << :other if params[:action] == 'create' && current_user.admin?
 #   permitted
 # end
+
+  preserve_default_filters!
+  remove_filter :pdf_file, :resource_type, :in_progress, :messages
+
   show do |export|
     attributes_table do
       row(:resource) do

--- a/app/admin/admin_representatives.rb
+++ b/app/admin/admin_representatives.rb
@@ -12,4 +12,7 @@ ActiveAdmin.register Representative, as: 'Representatives' do
 #   permitted
 # end
 
+  preserve_default_filters!
+  remove_filter :address
+
 end

--- a/app/admin/admin_respondents.rb
+++ b/app/admin/admin_respondents.rb
@@ -12,4 +12,6 @@ ActiveAdmin.register Respondent, as: 'Respondents' do
 #   permitted
 # end
 
+  preserve_default_filters!
+  remove_filter :address, :work_address
 end

--- a/app/admin/admin_uploaded_files.rb
+++ b/app/admin/admin_uploaded_files.rb
@@ -11,6 +11,10 @@ ActiveAdmin.register UploadedFile, as: 'UploadedFiles' do
 #   permitted << :other if params[:action] == 'create' && current_user.admin?
 #   permitted
 # end
+
+  preserve_default_filters!
+  remove_filter :file_attachment, :file_blob, :checksum
+
   show do
     attributes_table title: 'File Details' do
       row(:filename) { |f| link_to(f.filename, rails_blob_path(f.file, disposition: 'attachment')) }


### PR DESCRIPTION
This PR removes the association filters where a drop down 'select2' box was populate with ALL of the records from that association.  The size of the HTML file in production was enourmous because of this and the page was resdonding really slowly.

If we really do need these dropdowns for filtering by a particular associated record - will have to implement it better than activeadmin's standard way - perhaps using AJAX or passing  paginated JSON to the JS to populate the lists rather than the whole database.