### PR TITLE
Rubyzip updated to 1.2.2 - due to security issues 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,7 +232,7 @@ GEM
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
     ruby_dep (1.5.0)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     rufus-scheduler (3.5.2)
       fugit (~> 1.1, >= 1.1.5)
     sass (3.7.2)


### PR DESCRIPTION
This PR updated rubyzip to 1.2.2 - security concerns