### PR TITLE
Add CLOUD_PROVIDER environment variable to switch between amazon and …

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,8 @@ gem 'sentry-raven', '~> 2.7', '>= 2.7.4'
 # AWS SDK gem
 gem 'aws-sdk-s3', '~> 1.17'
 
+# Azure gem for active storage
+gem 'azure-storage', '~> 0.15.0.preview', require: false
 
 # Use uk_postcode to validate postcodes for manual generation
 gem 'uk_postcode', '~> 2.1'

--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ setup your own database etc.. Just go about things in the normal way, but rememb
 
 ### Important Environment Variables
 
+#### CLOUD_PROVIDER
+
+Defaults to 'amazon' at the moment - valid values are 'amazon' and 'azure'
+
+This switch will eventually be removed, it is only present for the transition from amazon to azure
+
 #### ATOS_API_URL
 
 The admin provides a basic ATOS API client to read the zip files that have been

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :amazon
+  config.active_storage.service = ENV.fetch('CLOUD_PROVIDER', 'amazon').to_sym
 
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -15,6 +15,13 @@ amazon:
   bucket: <%= ENV.fetch('S3_UPLOAD_BUCKET', '') %>
   <%= "endpoint: #{ENV.fetch('AWS_ENDPOINT')}" if ENV.key?('AWS_ENDPOINT') %>
   <%= "force_path_style: true" if ENV.fetch('AWS_S3_FORCE_PATH_STYLE', 'false') == 'true' %>
+azure:
+  service: AzureStorage
+  storage_account_name: <%= ENV.fetch('AZURE_STORAGE_ACCOUNT', 'devstoreaccount1') %>
+  storage_access_key: <%= ENV.fetch('AZURE_STORAGE_ACCESS_KEY', 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==') %>
+  container: <%= ENV.fetch('AZURE_STORAGE_CONTAINER', 'et-api-container') %>
+  <%= "use_path_style_uri: true" if ENV.fetch('AZURE_STORAGE_BLOB_FORCE_PATH_STYLE', 'false') == 'true' %>
+  <%= "storage_blob_host: '#{ENV['AZURE_STORAGE_BLOB_HOST']}'" if ENV.key?('AZURE_STORAGE_BLOB_HOST') %>
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
Add CLOUD_PROVIDER environment variable to switch between amazon and azure - RST-1679 ADMIN (Azure)

As with the other services - the admin needed to switch between azure and amazon as it uses active storage for reading files