### PR TITLE
RST-1759 ADMIN (Azure) Asset configuration

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,11 +28,10 @@ Rails.application.configure do
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
+  config.asset_host = ENV['ASSET_HOST'] if ENV['ASSET_HOST'].present?
+  config.assets.prefix = ENV['ASSET_PREFIX'] if ENV['ASSET_PREFIX'].present?
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
-
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache


### PR DESCRIPTION
RST-1759 ADMIN (Azure) Asset configuration

Doesnt need to be deployed specially - this is just ready for azure.